### PR TITLE
Separate json reading and deserialization (for foundry issue #42)

### DIFF
--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -263,7 +263,6 @@ pub fn deserialize_value_address<'de, D: Deserializer<'de>>(
     d.deserialize_str(ValueAddressVisitor)
 }
 
-// pub fn deserialize_from_path_to_json(path: &Path) -> Result<ProgramJson, ProgramError> {
 pub fn deserialize_program_json(path: &Path) -> Result<ProgramJson, ProgramError> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
@@ -273,8 +272,10 @@ pub fn deserialize_program_json(path: &Path) -> Result<ProgramJson, ProgramError
     Ok(program_json)
 }
 
-// pub fn deserialize_from_json_to_program(program_json: ProgramJson, entrypoint: &str) -> Result<Program, ProgramError> {
-pub fn deserialize_from_program_json(program_json: ProgramJson, entrypoint: &str) -> Result<Program, ProgramError> {
+pub fn deserialize_from_program_json(
+    program_json: ProgramJson,
+    entrypoint: &str,
+) -> Result<Program, ProgramError> {
     let entrypoint_pc = match program_json
         .identifiers
         .get(&format!("__main__.{}", entrypoint))

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -263,6 +263,7 @@ pub fn deserialize_value_address<'de, D: Deserializer<'de>>(
     d.deserialize_str(ValueAddressVisitor)
 }
 
+// pub fn deserialize_from_path_to_json(path: &Path) -> Result<ProgramJson, ProgramError> {
 pub fn deserialize_program_json(path: &Path) -> Result<ProgramJson, ProgramError> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
@@ -272,9 +273,8 @@ pub fn deserialize_program_json(path: &Path) -> Result<ProgramJson, ProgramError
     Ok(program_json)
 }
 
-pub fn deserialize_program(path: &Path, entrypoint: &str) -> Result<Program, ProgramError> {
-    let program_json: ProgramJson = deserialize_program_json(path)?;
-
+// pub fn deserialize_from_json_to_program(program_json: ProgramJson, entrypoint: &str) -> Result<Program, ProgramError> {
+pub fn deserialize_from_program_json(program_json: ProgramJson, entrypoint: &str) -> Result<Program, ProgramError> {
     let entrypoint_pc = match program_json
         .identifiers
         .get(&format!("__main__.{}", entrypoint))
@@ -305,6 +305,12 @@ pub fn deserialize_program(path: &Path, entrypoint: &str) -> Result<Program, Pro
         reference_manager: program_json.reference_manager,
         identifiers: program_json.identifiers,
     })
+}
+
+pub fn deserialize_program(path: &Path, entrypoint: &str) -> Result<Program, ProgramError> {
+    let program_json: ProgramJson = deserialize_program_json(path)?;
+
+    deserialize_from_program_json(program_json, entrypoint)
 }
 
 #[cfg(test)]

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -1,5 +1,5 @@
 use crate::serde::deserialize_program::{
-    deserialize_program, HintParams, Identifier, ReferenceManager,
+    deserialize_program, HintParams, Identifier, ReferenceManager, ProgramJson, deserialize_from_program_json
 };
 use crate::types::errors::program_errors::ProgramError;
 use crate::types::relocatable::MaybeRelocatable;
@@ -21,6 +21,9 @@ pub struct Program {
 impl Program {
     pub fn new(path: &Path, entrypoint: &str) -> Result<Program, ProgramError> {
         deserialize_program(path, entrypoint)
+    }
+    pub fn from_json(program: ProgramJson, entrypoint: &str) -> Result<Program, ProgramError> {
+        deserialize_from_program_json(program, entrypoint)
     }
 }
 

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -1,5 +1,6 @@
 use crate::serde::deserialize_program::{
-    deserialize_program, HintParams, Identifier, ReferenceManager, ProgramJson, deserialize_from_program_json
+    deserialize_from_program_json, deserialize_program, HintParams, Identifier, ProgramJson,
+    ReferenceManager,
 };
 use crate::types::errors::program_errors::ProgramError;
 use crate::types::relocatable::MaybeRelocatable;
@@ -30,8 +31,19 @@ impl Program {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::serde::deserialize_program::deserialize_program_json;
     use crate::{bigint, bigint_str};
     use num_traits::FromPrimitive;
+
+    #[test]
+    fn deserialize_program_from_json_test() {
+        let program_json = deserialize_program_json(Path::new(
+            "cairo_programs/manually_compiled/valid_program_a.json",
+        )).unwrap();
+        let program = Program::from_json(program_json, "main").unwrap();
+
+        test_deserialized_program(program);
+    }
 
     #[test]
     fn deserialize_program_test() {
@@ -41,6 +53,10 @@ mod tests {
         )
         .expect("Failed to deserialize program");
 
+        test_deserialized_program(program);
+    }
+
+    fn test_deserialized_program(program: Program) {
         let builtins: Vec<String> = Vec::new();
         let data: Vec<MaybeRelocatable> = vec![
             MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -39,7 +39,8 @@ mod tests {
     fn deserialize_program_from_json_test() {
         let program_json = deserialize_program_json(Path::new(
             "cairo_programs/manually_compiled/valid_program_a.json",
-        )).unwrap();
+        ))
+        .unwrap();
         let program = Program::from_json(program_json, "main").unwrap();
 
         test_deserialized_program(program);


### PR DESCRIPTION
# TITLE

Separate json reading and deserialization

## Description

This PR is part of the work done to solve this issue on cairo-foundry:
https://github.com/onlydustxyz/cairo-foundry/issues/42

Extracted the logic within `deserialize_program(path, entrypoint)` into another function `deserialize_from_program_json`, so in case we already have a ProgramJson, we do not need to do IO again.

Added a contructor `Program::from_json` using this extracted logic.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
