### PR TITLE
added Clone derivation for ProgramJson

### DIFF
--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -9,7 +9,7 @@ use serde::{de, de::MapAccess, de::SeqAccess, Deserialize, Deserializer};
 use serde_json::Number;
 use std::{collections::HashMap, fmt, fs::File, io::BufReader, path::Path};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ProgramJson {
     #[serde(deserialize_with = "deserialize_bigint_hex")]
     pub prime: BigInt,


### PR DESCRIPTION
## Description

This PR is a follow up of https://github.com/onlydustxyz/cairo-rs/pull/4 , that changed cairo-rs to avoid multiple IO when reading the same file with different entypoint. For this, we used ProgramJson, but it doesn't implement Clone or Copy, so it wasn't reusable.

This PR aims to fix it

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
