### PR TITLE
feat: add `post_step_instruction` hook

### DIFF
--- a/src/vm/hook.rs
+++ b/src/vm/hook.rs
@@ -6,7 +6,21 @@ use crate::types::exec_scope::ExecutionScopes;
 
 use super::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine};
 
+/// PreStepInstructionHook is called before the VirtualMachine
+/// will execute an instruction
 type PreStepInstructionHook = Arc<
+    dyn Fn(
+            &mut VirtualMachine,
+            &mut ExecutionScopes,
+            &HashMap<String, BigInt>,
+        ) -> Result<(), VirtualMachineError>
+        + Sync
+        + Send,
+>;
+
+/// PostStepInstructionHook is called after the VirtualMachine
+/// executed an instruction
+type PostStepInstructionHook = Arc<
     dyn Fn(
             &mut VirtualMachine,
             &mut ExecutionScopes,
@@ -19,12 +33,17 @@ type PreStepInstructionHook = Arc<
 #[derive(Clone)]
 pub struct Hooks {
     pre_step_instruction: PreStepInstructionHook,
+    post_step_instruction: PostStepInstructionHook,
 }
 
 impl Hooks {
-    pub fn new(pre_step_instruction: PreStepInstructionHook) -> Self {
+    pub fn new(
+        pre_step_instruction: PreStepInstructionHook,
+        post_step_instruction: PostStepInstructionHook,
+    ) -> Self {
         Hooks {
             pre_step_instruction,
+            post_step_instruction,
         }
     }
 
@@ -35,5 +54,14 @@ impl Hooks {
         constants: &HashMap<String, BigInt>,
     ) -> Result<(), VirtualMachineError> {
         (self.pre_step_instruction)(vm, exec_scopes, constants)
+    }
+
+    pub fn execute_post_step_instruction(
+        &self,
+        vm: &mut VirtualMachine,
+        exec_scopes: &mut ExecutionScopes,
+        constants: &HashMap<String, BigInt>,
+    ) -> Result<(), VirtualMachineError> {
+        (self.post_step_instruction)(vm, exec_scopes, constants)
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -585,10 +585,21 @@ impl VirtualMachine {
         self.step_hint(hint_executor, exec_scopes, hint_data_dictionary, constants)?;
 
         #[cfg(feature = "hooks")]
-        if let Ok(hooks) = exec_scopes.get_hooks() {
-            hooks.execute_pre_step_instruction(self, exec_scopes, constants)?;
+        {
+            if let Ok(hooks) = exec_scopes.get_hooks() {
+                hooks.execute_pre_step_instruction(self, exec_scopes, constants)?;
+            }
+
+            let res = self.step_instruction();
+
+            if let Ok(hooks) = exec_scopes.get_hooks() {
+                hooks.execute_post_step_instruction(self, exec_scopes, constants)?;
+            }
+
+            res
         }
 
+        #[cfg(not(feature = "hooks"))]
         self.step_instruction()
     }
 


### PR DESCRIPTION
# Add `post_step_instruction` hook

## Description

This pull request add `post_step_instruction` hook which will be called after the virtual machine executed an instruction.

This is needed to implement [afterEach in cairo-foundry](https://github.com/open-dust/cairo-foundry/issues/74)

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
 - [ ] Documentation has been added/updated.
