### PR TITLE
Making current_step public in vm

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -53,7 +53,7 @@ pub struct VirtualMachine {
     pub(crate) memory: Memory,
     accessed_addresses: Option<Vec<Relocatable>>,
     pub(crate) trace: Option<Vec<TraceEntry>>,
-    current_step: usize,
+    pub(crate) current_step: usize,
     skip_instruction_execution: bool,
 }
 


### PR DESCRIPTION
# TITLE

## Description

Making current_step public in vm as it's needed for (https://github.com/open-dust/cairo-foundry/issues/43) and it's already public in cairo-rs main

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
