### PR TITLE
 foundry: readd Program constructor from ProgramJson

### DIFF
--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -9,7 +9,7 @@ use serde_json::Number;
 use std::io::Read;
 use std::{collections::HashMap, fmt};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ProgramJson {
     #[serde(deserialize_with = "deserialize_bigint_hex")]
     pub prime: BigInt,
@@ -95,7 +95,7 @@ pub struct Location {
     pub start_col: u32,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct DebugInfo {
     instruction_locations: HashMap<usize, InstructionLocation>,
 }
@@ -313,12 +313,10 @@ pub fn deserialize_program_json(reader: impl Read) -> Result<ProgramJson, Progra
     Ok(program_json)
 }
 
-pub fn deserialize_program(
-    reader: impl Read,
+pub fn deserialize_program_from_json(
+    program_json: ProgramJson,
     entrypoint: Option<&str>,
 ) -> Result<Program, ProgramError> {
-    let program_json: ProgramJson = deserialize_program_json(reader)?;
-
     let entrypoint_pc = match entrypoint {
         Some(entrypoint) => match program_json
             .identifiers
@@ -372,6 +370,14 @@ pub fn deserialize_program(
             .debug_info
             .map(|debug_info| debug_info.instruction_locations),
     })
+}
+
+pub fn deserialize_program(
+    reader: impl Read,
+    entrypoint: Option<&str>,
+) -> Result<Program, ProgramError> {
+    let program_json: ProgramJson = deserialize_program_json(reader)?;
+    deserialize_program_from_json(program_json, entrypoint)
 }
 
 #[cfg(test)]

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -1,5 +1,6 @@
 use crate::serde::deserialize_program::{
-    deserialize_program, Attribute, HintParams, Identifier, InstructionLocation, ReferenceManager,
+    deserialize_program, deserialize_program_from_json, Attribute, HintParams, Identifier,
+    InstructionLocation, ProgramJson, ReferenceManager,
 };
 use crate::types::errors::program_errors::ProgramError;
 use crate::types::relocatable::MaybeRelocatable;
@@ -80,6 +81,13 @@ impl Program {
     ) -> Result<Program, ProgramError> {
         deserialize_program(reader, entrypoint)
     }
+
+    pub fn from_json(
+        program: ProgramJson,
+        entrypoint: Option<&str>,
+    ) -> Result<Program, ProgramError> {
+        deserialize_program_from_json(program, entrypoint)
+    }
 }
 
 impl Default for Program {
@@ -105,6 +113,7 @@ impl Default for Program {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::serde::deserialize_program::deserialize_program_json;
     use crate::{bigint, bigint_str};
     use num_traits::FromPrimitive;
 
@@ -264,6 +273,19 @@ mod tests {
         );
 
         assert!(program.is_err());
+    }
+
+    #[test]
+    fn deserialize_program_from_json_test() {
+        let file = File::open(Path::new(
+            "cairo_programs/manually_compiled/valid_program_a.json",
+        ))
+        .unwrap();
+        let reader = BufReader::new(file);
+        let program_json = deserialize_program_json(reader).unwrap();
+        let program = Program::from_json(program_json, Some("main")).unwrap();
+
+        test_deserialized_program(program);
     }
 
     #[test]


### PR DESCRIPTION
# TITLE

Program constructor from ProgramJson was removed during latest rebase
## Description

This pull request readd Program constructor from ProgramJson which was removed during latest rebase.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
